### PR TITLE
Moving GeoServer API URL and platform definition to webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "test:watch": "cross-env NODE_ENV=development jest --watch",
     "test:coverage": "cross-env NODE_ENV=development jest --coverage",
     "start": "cross-env NODE_ENV=development jest && esdoc -c esdoc.json && webpack-dev-server",
+    "mprj": "cross-env NODE_ENV=mprj jest && esdoc -c esdoc.json && webpack-dev-server",
     "prod": "cross-env NODE_ENV=production webpack-dev-server --env.prod=true",
     "build": "cross-env NODE_ENV=production webpack --env.prod=true",
     "lint": "eslint ./client ./webpack.config.js -f table || true",

--- a/src/components/Api/GeoAPI.js
+++ b/src/components/Api/GeoAPI.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
-const WORKSPACE = 'plataforma';
-const ENDPOINT  = `/geoserver/${WORKSPACE}/wms`;
+const WORKSPACE = __WORKSPACE__;
+const ENDPOINT  = __API__;
 
 const GeoAPI = {
 

--- a/src/components/App/reducers/geoServerXmlReducer.js
+++ b/src/components/App/reducers/geoServerXmlReducer.js
@@ -1,8 +1,8 @@
 import { parseBoundingBox, parseStyle } from './geoServerXmlStyleReducer';
 
-const RESTRICTED = false;       // TODO change for env var
-const WORKSPACE = 'plataforma'; // TODO change for env var
-const ENDPOINT  = `/geoserver/${WORKSPACE}/wms`;
+const RESTRICTED = false;
+const WORKSPACE = __WORKSPACE__;
+const ENDPOINT = __API__;
 
 /**
  * Parses XML response from GeoServer, creating a layers array

--- a/src/components/App/reducers/geoServerXmlStyleReducer.js
+++ b/src/components/App/reducers/geoServerXmlStyleReducer.js
@@ -1,6 +1,6 @@
 // styles constants
-const WORKSPACE = 'plataforma'; // TODO change for env var
-const ENDPOINT  = `/geoserver/${WORKSPACE}/wms`;
+const WORKSPACE = __WORKSPACE__;
+const ENDPOINT = __API__;
 const ICON_SIZE      = { x: 27,  y: 20  };
 const THUMB_SIZE     = { x: 225, y: 150 };
 const TOOLTIP_SIZE   = 750;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,11 +6,16 @@ const staticsPath = path.join(__dirname, './static');
 
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 
-var apiHost, workspace;
+var apiHost, workspace, geoServerURL;
 var setupAPI = function () {
     // eventually this could be different for `process.env.NODE_ENV`, but for now it will be the same
     workspace = "'plataforma'";
     apiHost = "'/geoserver/plataforma/wms'";
+    if(process.env.NODE_ENV === 'mprj'){
+        geoServerURL = 'http://p-mapas01:8080/geoserver';
+    } else {
+        geoServerURL = 'http://apps.mprj.mp.br/geoserver';
+    }
 }
 setupAPI();
 
@@ -154,13 +159,13 @@ module.exports = function (env) {
             hot: !isProd,
             proxy:{
                 '/geoserver/*' : {
-                    target: 'http://p-mapas01:8080/geoserver/', // http://apps.mprj.mp.br/geoserver/plataforma/wms?request=GetCapabilities -> http://localhost:3000/geoserver/plataforma/wms?request=GetCapabilities
+                    target: geoServerURL,
                     changeOrigin: true,
                     pathRewrite: {
-                    '^/geoserver': ''
+                        '^/geoserver': ''
                     }
                 }
-                },
+            },
             stats: {
                 assets: true,
                 children: false,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,6 +6,14 @@ const staticsPath = path.join(__dirname, './static');
 
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 
+var apiHost, workspace;
+var setupAPI = function () {
+    // eventually this could be different for `process.env.NODE_ENV`, but for now it will be the same
+    workspace = "'plataforma'";
+    apiHost = "'/geoserver/plataforma/wms'";
+}
+setupAPI();
+
 module.exports = function (env) {
     const nodeEnv = env && env.prod ? 'production' : 'development';
     const isProd = nodeEnv === 'production';
@@ -20,7 +28,11 @@ module.exports = function (env) {
             NODE_ENV: nodeEnv,
         }),
         new webpack.NamedModulesPlugin(),
-        new ExtractTextPlugin('static/styles.css')
+        new ExtractTextPlugin('static/styles.css'),
+        new webpack.DefinePlugin({
+            __API__: apiHost,
+            __WORKSPACE__: workspace
+        })
     ];
 
     var sassUse;


### PR DESCRIPTION
For now it doesn't change based on env - it doesn't matter, because we use a proxy for GeoServer anyways - but that can be done later if needed.
Fix #37