### PR TITLE
Resolving bug which made the first item layer array come empty

### DIFF
--- a/src/components/Menu/MenuItem.js
+++ b/src/components/Menu/MenuItem.js
@@ -11,7 +11,7 @@ const MenuItem = ({item, layers, onItemClick, onMouseOver, sidebarLeftWidth, sid
     let otherIsNotMatched = false
 
     // if `item`, which means it is a submenu with children
-    if(item){
+    if(item !== undefined){
         menuItemClassName = item.title ? 'menu-item-with-children' : 'menu-layer'
         menuItemClassName += item.selected ? ' selected' : ''
 


### PR DESCRIPTION
The first object on the layers had an empty value on the menu, the new comparisson solves it.
Paired with @rlage and @nighto 