### PR TITLE
Fixing focus on SidebarLeft/Search

### DIFF
--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -163,6 +163,12 @@ export const updateScrollTop = (scrollTop) => {
 }
 
 // on SidebarLeftContainer.js
+export const closeToolbars = () => {
+    return {
+        type: 'CLOSE_TOOLBARS',
+    }
+}
+
 export const searchLayer = (text) => {
     return {
         type: 'SEARCH_LAYER',

--- a/src/components/App/appReducer.js
+++ b/src/components/App/appReducer.js
@@ -414,6 +414,11 @@ const appReducer = (state = [], action) => {
                 currentLevel: 0,
                 menuItems: newMenuItems,
             }
+        case 'CLOSE_TOOLBARS':
+            return {
+                ...state,
+                toolbarActive: null,
+            }
         case 'SEARCH_LAYER':
             var newLayers = state.layers.map(l => searchLayer(l, action))
             var filteredLayers = newLayers.filter(layer => layer.match)

--- a/src/components/SearchLayer/SearchLayer.js
+++ b/src/components/SearchLayer/SearchLayer.js
@@ -1,14 +1,14 @@
 import React from 'react'
 
-const SearchLayer = ({onKeyUpSearch, onBtnCleanSearch, searchString}) => {
+const SearchLayer = ({onSearchClick, onKeyUpSearch, onBtnCleanSearch, searchString}) => {
     let input
     var searchIconClass = 'search-layer--icon fa fa-'
-    var onClickEvent = null
+    var onIconClick = null
     if (searchString !== undefined && searchString.length === 0) {
         searchIconClass += 'search'
     } else {
         searchIconClass += 'close'
-        onClickEvent = () => {
+        onIconClick = () => {
             input.value = ''
             onBtnCleanSearch()
         }
@@ -29,15 +29,20 @@ const SearchLayer = ({onKeyUpSearch, onBtnCleanSearch, searchString}) => {
         onKeyUpSearch(input.value)
     }
 
+    const inputOnClick = () => {
+        onSearchClick()
+    }
+
     return (
         <form action="#" className="search-layer" onSubmit={preventSubmit}>
             <label htmlFor="searchLayer" className="search-layer--title">
                 Ou pesquise por aqui:
-                <span className={searchIconClass} onClick={onClickEvent}></span>
+                <span className={searchIconClass} onClick={onIconClick}></span>
                 <input
                     type="text"
                     id="searchLayer"
                     ref={inputField}
+                    onClick={inputOnClick}
                     onKeyUp={inputOnKeyUp}
                     className="search-layer--input"
                     placeholder="Ex.: Escolas"/>

--- a/src/components/SidebarLeft/SidebarLeft.js
+++ b/src/components/SidebarLeft/SidebarLeft.js
@@ -8,6 +8,7 @@ const SidebarLeft = withContentRect(['bounds', 'client'])(({
     measureRef,
     measure,
     contentRect,
+    onSearchClick,
     onKeyUpSearch,
     showMenu,
     onClickMenuHeader,
@@ -22,7 +23,7 @@ const SidebarLeft = withContentRect(['bounds', 'client'])(({
             <div ref={measureRef} className={cssClass}>
                 <MenuHeader onClickMenuHeader={onClickMenuHeader}/>
                 <MenuContainer sidebarLeftWidth={contentRect.client.width} sidebarLeftHeight={contentRect.client.height}/>
-                <SearchLayer onKeyUpSearch={onKeyUpSearch} onBtnCleanSearch={onBtnCleanSearch} searchString={searchString}/>
+                <SearchLayer onSearchClick={onSearchClick} onKeyUpSearch={onKeyUpSearch} onBtnCleanSearch={onBtnCleanSearch} searchString={searchString}/>
             </div>
     )
 })

--- a/src/components/SidebarLeft/SidebarLeftContainer.js
+++ b/src/components/SidebarLeft/SidebarLeftContainer.js
@@ -1,10 +1,13 @@
 import React from 'react'
 import SidebarLeft from './SidebarLeft'
 import { connect } from 'react-redux'
-import { searchLayer, cleanSearch, hideMenuLayer, untoggleAll } from '../../actions/actions.js'
+import { closeToolbars, searchLayer, cleanSearch, hideMenuLayer, untoggleAll } from '../../actions/actions.js'
 
 const mapDispatchToProps = (dispatch) => {
     return {
+        onSearchClick: () => {
+            dispatch(closeToolbars())
+        },
         onKeyUpSearch: (text) => {
             dispatch(untoggleAll())
             dispatch(searchLayer(text))


### PR DESCRIPTION
When clicking on search field, close all toolbars,
to make sure neither SearchArea nor GoogleSearch are visible.

Fixes #355