### PR TITLE
Fix cluster rendering z-index

### DIFF
--- a/src/components/LeafletMap/leafletMap.scss
+++ b/src/components/LeafletMap/leafletMap.scss
@@ -139,3 +139,7 @@
 .leaflet-control-layers.leaflet-control {
     display: none;
 }
+
+// Fixes layer order
+.leaflet-tile-pane    { z-index: initial; }
+.leaflet-overlay-pane { z-index: initial; }


### PR DESCRIPTION
Fix default z-index, which was blocking rendering tile layers above
cluster (image) layers

There is still a pending error regarding layers orders, which
sometimes stops working

Fixes #411